### PR TITLE
feat: add offline guard

### DIFF
--- a/psych-study-platform/frontend/db.js
+++ b/psych-study-platform/frontend/db.js
@@ -1,0 +1,25 @@
+import Dexie from "dexie";
+
+export const db = new Dexie("meshi-events");
+db.version(1).stores({
+  events: "++id, type, payload",
+});
+
+export async function saveEvent(type, payload) {
+  return db.events.add({ type, payload });
+}
+
+async function getAllEvent() {
+  return db.events.toArray();
+}
+
+async function deleteEvent(id) {
+  return db.events.delete(id);
+}
+
+export async function sync() {
+  for await (const event of getAllEvent()) {
+    // make API call to backend
+    deleteEvent(event.id);
+  }
+}

--- a/psych-study-platform/frontend/package-lock.json
+++ b/psych-study-platform/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "grommet": "^2.22.0",
         "grommet-icons": "^4.7.0",
         "react": "^18.0.0",
+        "react-detect-offline": "^2.4.5",
         "react-dom": "^18.0.0",
         "react-intersection-observer": "^9.1.0",
         "react-router-dom": "^6.3.0",
@@ -2650,6 +2651,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-detect-offline": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/react-detect-offline/-/react-detect-offline-2.4.5.tgz",
+      "integrity": "sha512-sI13NPEKl3uQp95FT5CwrYzH3DnXCwNP6TnY6NRF5gFDM4NU9KDlbtA6HG2dwhDVS0RYQGXwZW/mHbdf8fCnaw=="
+    },
     "node_modules/react-dom": {
       "version": "18.0.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.0.0.tgz",
@@ -4732,6 +4738,11 @@
       "requires": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "react-detect-offline": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/react-detect-offline/-/react-detect-offline-2.4.5.tgz",
+      "integrity": "sha512-sI13NPEKl3uQp95FT5CwrYzH3DnXCwNP6TnY6NRF5gFDM4NU9KDlbtA6HG2dwhDVS0RYQGXwZW/mHbdf8fCnaw=="
     },
     "react-dom": {
       "version": "18.0.0",

--- a/psych-study-platform/frontend/package.json
+++ b/psych-study-platform/frontend/package.json
@@ -19,6 +19,7 @@
     "grommet": "^2.22.0",
     "grommet-icons": "^4.7.0",
     "react": "^18.0.0",
+    "react-detect-offline": "^2.4.5",
     "react-dom": "^18.0.0",
     "react-intersection-observer": "^9.1.0",
     "react-router-dom": "^6.3.0",

--- a/psych-study-platform/frontend/pages/Feed.js
+++ b/psych-study-platform/frontend/pages/Feed.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useRecoilState, useRecoilValue } from "recoil";
 import { useNavigate } from "react-router-dom";
-import { Box, Text } from "grommet";
+import { Box, Heading, Text } from "grommet";
 import { User } from "grommet-icons";
 import { Section } from "~/components/atoms/Section";
 import { useApi } from "~/api/hook";
@@ -14,6 +14,7 @@ import { FeedPostTestSurvey } from "../components/molecules/FeedPostTestSurvey";
 import { FeedFinished } from "../components/molecules/FeedFinished";
 import { usePageVisibility } from "~/components/atoms/usePageVisibility";
 import { UserMetricLabelState } from "../UserState";
+import { Offline, Online } from "react-detect-offline";
 
 export function Feed() {
   let navigate = useNavigate();
@@ -42,32 +43,43 @@ export function Feed() {
 
   return (
     <Box>
-      {user.id ? (
-        <Box>
-          <Section>
-            <Box round={"small"} border pad={"small"}>
-              <Box direction={"row"} gap={"small"} align={"center"}>
-                <User size={"large"} />
-                <Text weight={800} size={"xxlarge"}>
-                  {user.username + " | " + userMetricLabel}
-                </Text>
+      <Online>
+        {user.id ? (
+          <Box>
+            <Section>
+              <Box round={"small"} border pad={"small"}>
+                <Box direction={"row"} gap={"small"} align={"center"}>
+                  <User size={"large"} />
+                  <Text weight={800} size={"xxlarge"}>
+                    {user.username + " | " + userMetricLabel}
+                  </Text>
+                </Box>
               </Box>
-            </Box>
-            <Box flex={"grow"}></Box>
-          </Section>
-          {/* <Text>{JSON.stringify(data)}</Text> */}
-          {data && data.type === "POSTS" ? <UserFeed data={data} /> : null}
-          {data && data.type === "PAGE" && data.page === "ONBOARDING" ? (
-            <FeedOnboarding />
-          ) : null}
-          {data && data.type === "PAGE" && data.page === "POST_TEST_SURVEY" ? (
-            <FeedPostTestSurvey />
-          ) : null}
-          {data && data.type === "PAGE" && data.page === "FINISHED" ? (
-            <FeedFinished />
-          ) : null}
-        </Box>
-      ) : null}
+              <Box flex={"grow"}></Box>
+            </Section>
+            {/* <Text>{JSON.stringify(data)}</Text> */}
+            {data && data.type === "POSTS" ? <UserFeed data={data} /> : null}
+            {data && data.type === "PAGE" && data.page === "ONBOARDING" ? (
+              <FeedOnboarding />
+            ) : null}
+            {data &&
+            data.type === "PAGE" &&
+            data.page === "POST_TEST_SURVEY" ? (
+              <FeedPostTestSurvey />
+            ) : null}
+            {data && data.type === "PAGE" && data.page === "FINISHED" ? (
+              <FeedFinished />
+            ) : null}
+          </Box>
+        ) : null}
+      </Online>
+      <Offline>
+        <Heading>We've lost internet connectivity.</Heading>
+        <Text>
+          This test requires a stable internet connection to accurately measure
+          your interactions. Please resume once the internet is back.
+        </Text>
+      </Offline>
     </Box>
   );
 }

--- a/psych-study-platform/package-lock.json
+++ b/psych-study-platform/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "concurrently": "^7.1.0"
+        "concurrently": "^7.1.0",
+        "dexie": "^3.2.2"
       },
       "devDependencies": {
         "process": "^0.11.10"
@@ -120,6 +121,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/dexie": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-3.2.2.tgz",
+      "integrity": "sha512-q5dC3HPmir2DERlX+toCBbHQXW5MsyrFqPFcovkH9N2S/UW/H3H5AWAB6iEOExeraAu+j+zRDG+zg/D7YhH0qg==",
+      "engines": {
+        "node": ">=6.0"
       }
     },
     "node_modules/emoji-regex": {
@@ -373,6 +382,11 @@
       "version": "2.28.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
       "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
+    },
+    "dexie": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-3.2.2.tgz",
+      "integrity": "sha512-q5dC3HPmir2DERlX+toCBbHQXW5MsyrFqPFcovkH9N2S/UW/H3H5AWAB6iEOExeraAu+j+zRDG+zg/D7YhH0qg=="
     },
     "emoji-regex": {
       "version": "8.0.0",

--- a/psych-study-platform/package.json
+++ b/psych-study-platform/package.json
@@ -13,7 +13,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "concurrently": "^7.1.0"
+    "concurrently": "^7.1.0",
+    "dexie": "^3.2.2"
   },
   "devDependencies": {
     "process": "^0.11.10"


### PR DESCRIPTION
Added a crude protection against bad network. The app stalls till network resumes and does not allow you to proceed with the test if the network is bad.
Also added a database to store data in case of bad network to be synced later. Can explore this later. 